### PR TITLE
Fix error with JDK 11

### DIFF
--- a/src/main/java/com/devoteam/srit/xmlloader/gui/model/ModelTreeRTStats.java
+++ b/src/main/java/com/devoteam/srit/xmlloader/gui/model/ModelTreeRTStats.java
@@ -248,7 +248,7 @@ public class ModelTreeRTStats extends DefaultTreeModel {
         boolean alreadyExist = false;
 
         // We get all children of node parent
-        Enumeration<DefaultMutableTreeNode> allChildren = nodeParent.children();
+        Enumeration<DefaultMutableTreeNode> allChildren = (Enumeration<DefaultMutableTreeNode>)(Object)nodeParent.children();
 
         // For each child
         while (allChildren.hasMoreElements()) {
@@ -298,7 +298,7 @@ public class ModelTreeRTStats extends DefaultTreeModel {
         DefaultMutableTreeNode node = null;
 
         // We get all children of node parent
-        Enumeration<DefaultMutableTreeNode> allChildren = nodeParent.children();
+        Enumeration<DefaultMutableTreeNode> allChildren = (Enumeration<DefaultMutableTreeNode>)(Object)nodeParent.children();
 
         // For each child
         while (allChildren.hasMoreElements()) {


### PR DESCRIPTION
When you try to generate the package with `mvn package`, and you use OpenJDK 11, you have the following error :

```
[ERROR] /home/uvma7494/git/mts/forked_mts/mts/src/main/java/com/devoteam/srit/xmlloader/gui/model/ModelTreeRTStats.java:[251,77] error: incompatible types: Enumeration<TreeNode> cannot be converted to Enumeration<DefaultMutableTreeNode>
[ERROR] /home/uvma7494/git/mts/forked_mts/mts/src/main/java/com/devoteam/srit/xmlloader/gui/model/ModelTreeRTStats.java:[301,77] error: incompatible types: Enumeration<TreeNode> cannot be converted to Enumeration<DefaultMutableTreeNode>
```

It seems to be the same issue as https://github.com/chatty/chatty/issues/241

I tested it on my Ubuntu 18.04 with `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64` and it seems to work.

I didn't have time to test the retro compatibility with open-jdk 8.

