### PR TITLE
Orangeft4cs functions path

### DIFF
--- a/src/main/java/com/devoteam/srit/xmlloader/core/operations/basic/OperationFunction.java
+++ b/src/main/java/com/devoteam/srit/xmlloader/core/operations/basic/OperationFunction.java
@@ -69,6 +69,13 @@ public class OperationFunction extends Operation {
     }
 
     public static void importFile(String file, URI relativeTo) throws Exception {
+
+        // Solve user_home value
+        if (file.contains("[user_home]")) {
+            String userHome = System.getProperty("user.home");
+            file = file.replace("[user_home]", userHome);
+        }
+
         // parse the xml file
         XMLDocument scenarioDocument = Cache.getXMLDocument(relativeTo.resolve(file), URIFactory.newURI("../conf/schemas/scenario.xsd"));
 

--- a/src/main/java/com/devoteam/srit/xmlloader/core/operations/basic/OperationGroovy.java
+++ b/src/main/java/com/devoteam/srit/xmlloader/core/operations/basic/OperationGroovy.java
@@ -91,6 +91,12 @@ public class OperationGroovy extends Operation {
         // retrieve the list of groovy files to load
         String groovyFiles = getRootElement().attributeValue("name");
 
+        // Solve user_home value
+        if (groovyFiles.contains("[user_home]")) {
+            String userHome = System.getProperty("user.home");
+            groovyFiles = groovyFiles.replace("[user_home]", userHome);
+        }
+
         // retrieve the groovy operation script source
         String scriptSource = getRootElement().getText();
 


### PR DESCRIPTION
In order to ease the location of functions we have improved importFile() function in OperationFunction.java file.
This modification allows developer to define absolute path instead of relative path based on user HOME directory. 
This allows to include a same function from several directories location and no more play with relative path. It improves the robustness in case of code/lib refactoring, improve code re-usage, ease library imports for developers.

Usage example in a scenario: 
<function file= "[user_home]/workspace/ft4cs-engine/VoiceFrameworkLibs/engineV3/leg_functions/Gen_Mob_BT_calls_B.xml"/>

Then [user_home] parameter must be solved by MTS framework. To allows this parameter resolution please find below modification to apply in the code: highlighted in yellow color.

File location:
src/main/java/com/devoteam/srit/xmlloader/core/operations/basic/OperationFunction.java

Modification to apply in the code
    public static void importFile(String file, URI relativeTo) throws Exception {

        // Solve user_home value
        if (file.contains("[user_home]")) {
            String userHome = System.getProperty("user.home");
            file = file.replace("[user_home]", userHome);
        }	

        // parse the xml file
        XMLDocument scenarioDocument = Cache.getXMLDocument(relativeTo.resolve(file), URIFactory.newURI("../conf/schemas/scenario.xsd"));

        // get all <function> element
        for (Object object : scenarioDocument.getDocument().selectNodes("//function")) {
            Element element = (Element) object;
            // create operation function for each (that will register them or go into files again)
            
            GlobalLogger.instance().getApplicationLogger().info(TextEvent.Topic.CORE, "adding function from file ", relativeTo.resolve(file));
            OperationFunction temp = new OperationFunction(element);
        }

        // TODO : /!\ warning cyclic files reference bug ahead ! should keep track of parsed files
    }

-----------------------------------------------------------


Applying the same logic as mentioned before.
In order to ease the location of groovy functions we have improved execute() function in OperationGroovy.java


Usage example in a scenario: 

<groovy name="[user_home]/workspace/ft4cs-engine/VoiceFrameworkLibs/resources/functionCollections/Functions_Control.groovy">groovy_Functions_Control.control(GroovyCallerControl)</groovy>



Then [user_home] parameter must be solved by MTS framework. To allows this parameter resolution please find below modification to apply in the code: highlighted in yellow color.


File location:
src/main/java/com/devoteam/srit/xmlloader/core/operations/basic/OperationGroovy.java

Modification to apply in the code


    public Operation execute(Runner runner) throws Exception {
        if (runner instanceof ScenarioRunner) {
            GlobalLogger.instance().getSessionLogger().info(runner, TextEvent.Topic.CORE, this);
        } else {
            GlobalLogger.instance().getApplicationLogger().info(TextEvent.Topic.CORE, this);
        }

        // retrieve the list of groovy files to load
        String groovyFiles = getRootElement().attributeValue("name");

        // Solve user_home value
        if (groovyFiles.contains("[user_home]")) {
            String userHome = System.getProperty("user.home");
            groovyFiles = groovyFiles.replace("[user_home]", userHome);
        }

        // retrieve the groovy operation script source
        String scriptSource = getRootElement().getText();
