### PR TITLE
feat: Functions Path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <dom4j.version>2.1.3</dom4j.version>
         <jaxen.version>2.0.0</jaxen.version>
         <snakeyaml.version>2.0</snakeyaml.version>
+        <commons-text.version>1.10.0</commons-text.version>
         <httpcore5.version>5.0-beta9</httpcore5.version>
         <opencsv.version>2.3</opencsv.version>
         <jain-sip-api.version>1.2.1.4</jain-sip-api.version>
@@ -384,6 +385,11 @@
             <artifactId>jaxen</artifactId>
             <version>${jaxen.version}</version>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons-text.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents.core5</groupId>

--- a/src/main/java/com/devoteam/srit/xmlloader/core/operations/basic/OperationFunction.java
+++ b/src/main/java/com/devoteam/srit/xmlloader/core/operations/basic/OperationFunction.java
@@ -30,6 +30,7 @@ import com.devoteam.srit.xmlloader.core.log.GlobalLogger;
 import com.devoteam.srit.xmlloader.core.log.TextEvent;
 import com.devoteam.srit.xmlloader.core.operations.Operation;
 import com.devoteam.srit.xmlloader.core.operations.functions.FunctionsRegistry;
+import com.devoteam.srit.xmlloader.core.utils.EnvUtils;
 import com.devoteam.srit.xmlloader.core.utils.URIFactory;
 import com.devoteam.srit.xmlloader.core.utils.URIRegistry;
 import com.devoteam.srit.xmlloader.core.utils.XMLDocument;
@@ -70,14 +71,15 @@ public class OperationFunction extends Operation {
 
     public static void importFile(String file, URI relativeTo) throws Exception {
         // parse the xml file
-        XMLDocument scenarioDocument = Cache.getXMLDocument(relativeTo.resolve(file), URIFactory.newURI("../conf/schemas/scenario.xsd"));
+        URI resolvedURI = URIFactory.resolveURI(EnvUtils.resolveSystemOrEnvProperties(file), relativeTo);
+        XMLDocument scenarioDocument = Cache.getXMLDocument(resolvedURI, URIFactory.newURI("../conf/schemas/scenario.xsd"));
 
         // get all <function> element
         for (Object object : scenarioDocument.getDocument().selectNodes("//function")) {
             Element element = (Element) object;
             // create operation function for each (that will register them or go into files again)
             
-            GlobalLogger.instance().getApplicationLogger().info(TextEvent.Topic.CORE, "adding function from file ", relativeTo.resolve(file));
+            GlobalLogger.instance().getApplicationLogger().info(TextEvent.Topic.CORE, "adding function from file ", resolvedURI);
             OperationFunction temp = new OperationFunction(element);
         }
 
@@ -86,7 +88,7 @@ public class OperationFunction extends Operation {
 
     public static void importDir(String dir, URI relativeTo) throws Exception {
         // try to add all files from a dir; should only contain xml files
-        URI dirUri = relativeTo.resolve(dir);
+        URI dirUri = URIFactory.resolveURI(EnvUtils.resolveSystemOrEnvProperties(dir), relativeTo);
         GlobalLogger.instance().getApplicationLogger().info(TextEvent.Topic.CORE, "adding function from dir ", dirUri);
         if (SingletonFSInterface.instance().exists(dirUri)) {
             String[] files = SingletonFSInterface.instance().list(dirUri);

--- a/src/main/java/com/devoteam/srit/xmlloader/core/operations/basic/OperationGroovy.java
+++ b/src/main/java/com/devoteam/srit/xmlloader/core/operations/basic/OperationGroovy.java
@@ -26,6 +26,8 @@ import java.io.File;
 import java.util.Map;
 import java.util.StringTokenizer;
 
+import com.devoteam.srit.xmlloader.core.utils.EnvUtils;
+import com.devoteam.srit.xmlloader.core.utils.URIFactory;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.dom4j.Element;
 
@@ -89,7 +91,7 @@ public class OperationGroovy extends Operation {
         }
 
         // retrieve the list of groovy files to load
-        String groovyFiles = getRootElement().attributeValue("name");
+        String groovyFiles = EnvUtils.resolveSystemOrEnvProperties(getRootElement().attributeValue("name"));
 
         // retrieve the groovy operation script source
         String scriptSource = getRootElement().getText();
@@ -111,7 +113,7 @@ public class OperationGroovy extends Operation {
                 StringTokenizer st = new StringTokenizer(groovyFiles, ";");
                 while (st.hasMoreTokens()) {
                     String scriptName = st.nextToken();
-                    File file = new File(URIRegistry.MTS_TEST_HOME.resolve(scriptName));
+                    File file = new File(URIFactory.resolveURI(scriptName, URIRegistry.MTS_TEST_HOME));
                     if (file.exists() && file.getName().endsWith(".groovy")) {
                         Class groovyClass = groovyClassLoader.parseClass(file);
                         Object obj = groovyClass.newInstance();

--- a/src/main/java/com/devoteam/srit/xmlloader/core/utils/EnvUtils.java
+++ b/src/main/java/com/devoteam/srit/xmlloader/core/utils/EnvUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Ericsson, https://www.ericsson.com/en
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.devoteam.srit.xmlloader.core.utils;
+
+import org.apache.commons.text.StringSubstitutor;
+import org.apache.commons.text.lookup.StringLookupFactory;
+
+public class EnvUtils {
+
+    static final String ENV_SYSTEM_PROPERTY_PREFIX = "env.SYSTEM_PROPERTY_PREFIX";
+    static final String ENV_SYSTEM_PROPERTY_SUFFIX = "env.SYSTEM_PROPERTY_SUFFIX";
+    static final String ENV_SYSTEM_PROPERTY_ESCAPE_CHAR = "env.SYSTEM_PROPERTY_ESCAPE_CHAR";
+
+    public static String resolveSystemOrEnvProperties(String filePath) {
+        Config config = Config.getConfigByName("tester.properties");
+        return new StringSubstitutor(
+                s -> {
+                    String val = StringLookupFactory.INSTANCE.systemPropertyStringLookup().lookup(s);
+                    return val != null ? val : StringLookupFactory.INSTANCE.environmentVariableStringLookup().lookup(s);
+                },
+                getPrefix(config),
+                getSuffix(config),
+                getEscapeCharacter(config))
+                .replace(filePath);
+    }
+
+    static String getPrefix(Config config) {
+        String property = config.getString(ENV_SYSTEM_PROPERTY_PREFIX, "");
+        return property.isEmpty() ? StringSubstitutor.DEFAULT_VAR_START : property;
+    }
+
+    static String getSuffix(Config config) {
+        String property = config.getString(ENV_SYSTEM_PROPERTY_SUFFIX, "");
+        return property.isEmpty() ? StringSubstitutor.DEFAULT_VAR_END : property;
+    }
+
+    static Character getEscapeCharacter(Config config) {
+        String property = config.getString(ENV_SYSTEM_PROPERTY_ESCAPE_CHAR, "");
+        return property.isEmpty() ? StringSubstitutor.DEFAULT_ESCAPE : property.charAt(0);
+    }
+}

--- a/src/main/java/com/devoteam/srit/xmlloader/core/utils/URIFactory.java
+++ b/src/main/java/com/devoteam/srit/xmlloader/core/utils/URIFactory.java
@@ -23,6 +23,7 @@
 
 package com.devoteam.srit.xmlloader.core.utils;
 
+import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -56,5 +57,16 @@ public class URIFactory
     public static URI resolve(URI uri, String string)
     {
         return uri.resolve(doPath(string));
+    }
+
+    /**
+     * Make URI resolution regarding the type of the file path (absolute/relative)
+     * @param filePath the path of the file
+     * @param relativeTo reference URI for relative path
+     * @return the new URI
+     */
+    public static URI resolveURI(String filePath, URI relativeTo) {
+        File file = new File(filePath);
+        return file.isAbsolute() ? file.toURI() : relativeTo.resolve(filePath);
     }
 }

--- a/src/test/java/com/devoteam/srit/xmlloader/core/utils/EnvUtilsTest.java
+++ b/src/test/java/com/devoteam/srit/xmlloader/core/utils/EnvUtilsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 Ericsson, https://www.ericsson.com/en
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.devoteam.srit.xmlloader.core.utils;
+
+import com.devoteam.srit.xmlloader.core.utils.filesystem.LocalFSInterface;
+import com.devoteam.srit.xmlloader.core.utils.filesystem.SingletonFSInterface;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class EnvUtilsTest {
+
+    @Before
+    public void setUp() {
+        Config.reset();
+        URIRegistry.MTS_CONFIG_HOME = new File("src/main/conf/").toURI();
+        SingletonFSInterface.setInstance(new LocalFSInterface());
+    }
+
+    @Test
+    public void testWithDefaultValues() {
+        URIRegistry.MTS_CONFIG_HOME = new File("src/main/conf/").toURI();
+        Config config = Config.getConfigByName("tester.properties");
+        assertEquals("${", EnvUtils.getPrefix(config));
+        assertEquals("}", EnvUtils.getSuffix(config));
+        assertEquals('$', (char) EnvUtils.getEscapeCharacter(config));
+    }
+
+    @Test
+    public void testWithCustomProperties() {
+        URIRegistry.MTS_CONFIG_HOME = new File("src/test/resources/conf/").toURI();
+        Config config = Config.getConfigByName("tester.properties");
+        assertEquals("#[", EnvUtils.getPrefix(config));
+        assertEquals("]", EnvUtils.getSuffix(config));
+        assertEquals('#', (char) EnvUtils.getEscapeCharacter(config));
+    }
+
+    @Test
+    public void testResolveSystemPropertiesWithDefaultValues() {
+        URIRegistry.MTS_CONFIG_HOME = new File("src/main/conf/").toURI();
+        String path = "${user.home}/env/test";
+        System.getProperties().setProperty("user.home", "myHomeDirectory");
+        String expectedResult = "myHomeDirectory/env/test";
+        assertEquals(expectedResult, EnvUtils.resolveSystemOrEnvProperties(path));
+    }
+
+    @Test
+    public void testResolveEnvPropertiesWithDefaultValues() {
+        URIRegistry.MTS_CONFIG_HOME = new File("src/main/conf/").toURI();
+        String pathEnv = System.getenv("PATH");
+        String myPath = "My path : ${PATH}";
+        String expectedResult = "My path : " + pathEnv;
+        assertEquals(expectedResult, EnvUtils.resolveSystemOrEnvProperties(myPath));
+    }
+
+    @Test
+    public void testResolveSystemPropertiesWitCustomProperties() {
+        URIRegistry.MTS_CONFIG_HOME = new File("src/test/resources/conf/").toURI();
+        System.getProperties().setProperty("user.home", "myHomeDirectory");
+
+        String path1 = "${user.home}/env/test";
+        assertEquals("${user.home}/env/test", EnvUtils.resolveSystemOrEnvProperties(path1));
+
+        String path2 = "#[user.home]/env/test";
+        String expectedResult = "myHomeDirectory/env/test";
+        assertEquals(expectedResult, EnvUtils.resolveSystemOrEnvProperties(path2));
+    }
+
+    @Test
+    public void testEscapeCharacter() {
+        URIRegistry.MTS_CONFIG_HOME = new File("src/main/conf/").toURI();
+        String path = "${user.home}/${user.directory}/test";
+        System.getProperties().setProperty("user.home", "myHomeDirectory");
+        System.getProperties().setProperty("user.directory", "myUserDirectory");
+
+        String expectedResult = "myHomeDirectory/myUserDirectory/test";
+        assertEquals(expectedResult, EnvUtils.resolveSystemOrEnvProperties(path));
+
+        path = "$${user.home}/$${user.directory}/test";
+        expectedResult = "${user.home}/${user.directory}/test";
+        assertEquals(expectedResult, EnvUtils.resolveSystemOrEnvProperties(path));
+    }
+ }

--- a/src/test/java/com/devoteam/srit/xmlloader/core/utils/URIFactoryTest.java
+++ b/src/test/java/com/devoteam/srit/xmlloader/core/utils/URIFactoryTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Ericsson, https://www.ericsson.com/en
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.devoteam.srit.xmlloader.core.utils;
+
+import com.devoteam.srit.xmlloader.core.utils.filesystem.LocalFSInterface;
+import com.devoteam.srit.xmlloader.core.utils.filesystem.SingletonFSInterface;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URI;
+
+public class URIFactoryTest {
+
+    @Before
+    public void setUp() {
+        Config.reset();
+        URIRegistry.MTS_CONFIG_HOME = new File("src/main/conf/").toURI();
+        SingletonFSInterface.setInstance(new LocalFSInterface());
+    }
+
+    @Test
+    public void testResolveURI(){
+
+        String fileName = "../function";
+        URI relativeTo = URIRegistry.MTS_BIN_HOME;
+        URI result = URIFactory.resolveURI(fileName, relativeTo);
+        Assert.assertEquals(URIRegistry.MTS_BIN_HOME.resolve(fileName), result);
+
+        fileName = EnvUtils.resolveSystemOrEnvProperties("${user.home}/function");
+        result = URIFactory.resolveURI(fileName, relativeTo);
+        Assert.assertEquals(new File(fileName).toURI(), result);
+    }
+}

--- a/src/test/resources/conf/tester.properties
+++ b/src/test/resources/conf/tester.properties
@@ -1,0 +1,25 @@
+
+###############################################################################
+#                                                                             #
+#                          Config file                                        #
+#                         CORE module                                         #
+#                                                                             #
+###############################################################################
+
+###############################################################################
+#                                                                             #
+# Environment : env variable processing                                       #
+#                                                                             #
+###############################################################################
+
+# Prefix used to identify starting of system properties in variable
+# [String] (restart)
+env.SYSTEM_PROPERTY_PREFIX = #[
+
+# Suffix used to identify ending of system properties in variable
+# [String] (restart)
+env.SYSTEM_PROPERTY_SUFFIX = ]
+
+# Escape character for system properties in variable
+# [char] (restart)
+env.SYSTEM_PROPERTY_ESCAPE_CHAR = #


### PR DESCRIPTION
 - Support of absolute path when importing operation functions from scenario.
 - Support of environment variables or java system properties in function path. Usage examples : ${HOME}/myFunctions , ${user.home}/myFunctions
 - Syntax definition can be customized through the core configuration file.

 - Impacted classes :  OperationFunction, OperationGroovy

 - Usage example for OperationGroovy: <scenario> <groovy name="${user.home}/TestParams.groovy;..."> ...

 - Usage example for OperationFunction: <scenario> <function file="${HOME}/function.xml" /> ...

Refs: MTSCUFBAT-4