### PR TITLE
[FIX] Correction of the setMTSParam method in the case of a list variable.

### DIFF
--- a/src/main/groovy/MTSScript.groovy
+++ b/src/main/groovy/MTSScript.groovy
@@ -224,9 +224,9 @@ abstract class MTSScript extends Script {
     protected void setMTSParam(String name, Object value) {
         try {
             //println "MTSBinder.setMTSParam($name)"
-            Parameter groovyParameter
-            if (value != null && value instanceof List) {
-                value.each{groovyParameter= parseParameter(it)}
+            Parameter groovyParameter = new Parameter();
+	    if (value != null && value instanceof List) {
+                value.each{groovyParameter.add(parseParameter(it))}
             } else {
                 groovyParameter= parseParameter(value);
             }


### PR DESCRIPTION
I have made a correction to the **setMTSParam** method (MTSScript.groovy) to avoid overwriting the list on each iteration (see: issue https://github.com/ericsson-mts/mts/issues/64). 
This allows to set a 'list' variable into MTS ParameterPool.

```
    /**
     * set a variable into MTS ParameterPool
     *
     */
    protected void setMTSParam(String name, Object value) {
        try {
            //println "MTSBinder.setMTSParam($name)"
            Parameter groovyParameter = new Parameter();
            if (value != null && value instanceof List) {
                value.each{groovyParameter.add(parseParameter(it))}
            } else {
                groovyParameter= parseParameter(value);
            }
            binding.runner.getParameterPool().set(ParameterPool.bracket(name), groovyParameter);
        } catch (ParameterException e) {
            e;
            e.printStackTrace();
        }
    }
```